### PR TITLE
Update 2019-07-29.incoming-mail-laravel-mailbox.md

### DIFF
--- a/content/posts/2019-07-29.incoming-mail-laravel-mailbox.md
+++ b/content/posts/2019-07-29.incoming-mail-laravel-mailbox.md
@@ -195,7 +195,7 @@ class IncomingEmailTest extends TestCase {
     tap(ReceivedMail::first(), function ($mail) use ($sender, $subject, $body) {
         $this->assertEquals($sender, $mail->sender);    
         $this->assertEquals($subject, $mail->subject);    
-        $this->assertContains($body, $mail->body);    
+        $this->assertStringContainsString($body, $mail->body);    
     });
   }
 }
@@ -227,7 +227,7 @@ class TestMail extends Mailable {
         return $this
             ->from($this->sender)
             ->subject($this->subject)
-            ->markdown('tests.emails.testmail');
+            ->markdown('emails.tests.testmail');
     }
 }
 ```


### PR DESCRIPTION
Hi John 👋,

Happy holidays, and thank you for the amazing blog post! I am pull requesting two small changes that will hopefully help the next person following your tutorial. The first one is a typo in the email template name in the `IncomingEmail` class and the second is a change to the assertion made in the tests. PHPUnit was throwing an exception that the haystack needs to be an iterable value, but the `ReceivedMail` body property returns just a string, so I swapped out the assertion and everything should pass 👍

Thanks again, cheers!

Wyatt

References: 
 - https://phpunit.readthedocs.io/en/9.5/assertions.html#assertcontains